### PR TITLE
Ocamldoc and Stdlib, what a nice mess!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ splash*.*
 *.project.local
 src/oebuild/oebuild
 src/oebuild/oebuild.opt
+src/stdlib_pp/stdlib_pp
+src/stdlib_pp/stdlib_pp.opt
+src/stdlib_pp/stdlib_pp.ml
 src/ocamleditor
 src/ocamleditor.opt
 src/gtkThread2.ml

--- a/build.ml
+++ b/build.ml
@@ -3152,9 +3152,40 @@ let targets = [
   };
   
   (* 2 *)
+  "stdlib_pp", {
+    descr                = "";
+    num                  = 2;
+    id                   = 28;
+    output_name          = "stdlib_pp/stdlib_pp";
+    target_type          = Executable;
+    compilation_bytecode = true;
+    compilation_native   = true;
+    toplevel_modules     = "stdlib_pp/stdlib_pp.ml";
+    package              = "";
+    search_path          = ""; (* -I *)
+    required_libraries   = "";
+    compiler_flags       = "";
+    linker_flags         = "";
+    thread               = false;
+    vmthread             = false;
+    pp                   = "";
+    inline               = None;
+    nodep                = false;
+    dontlinkdep          = false;
+    dontaddopt           = false;
+    library_install_dir  = ""; (* Relative to the Standard Library Directory *)
+    other_objects        = "";
+    external_tasks       = [];
+    restrictions         = [];
+    dependencies         = [];
+    show                 = true;
+    rc_filename          = None;
+  };
+  
+  (* 3 *)
   "gmisclib", {
     descr                = "Miscellaneous widgets based on LablGtk2.";
-    num                  = 2;
+    num                  = 3;
     id                   = 8;
     output_name          = "gmisclib";
     target_type          = Library;
@@ -3182,7 +3213,7 @@ let targets = [
     rc_filename          = None;
   };
   
-  (* 2 *)
+  (* 3 *)
   "otherwidgets", {
     descr                = "";
     num                  = 0;
@@ -3213,10 +3244,10 @@ let targets = [
     rc_filename          = None;
   };
   
-  (* 3 *)
+  (* 4 *)
   "ocamleditor", {
     descr                = "";
-    num                  = 3;
+    num                  = 4;
     id                   = 12;
     output_name          = "ocamleditor";
     target_type          = Executable;
@@ -3244,10 +3275,10 @@ let targets = [
     rc_filename          = None;
   };
   
-  (* 4 *)
+  (* 5 *)
   "ocamleditor-bytecode", {
     descr                = "";
-    num                  = 4;
+    num                  = 5;
     id                   = 0;
     output_name          = "ocamleditor";
     target_type          = Executable;
@@ -3270,15 +3301,15 @@ let targets = [
     other_objects        = "";
     external_tasks       = [];
     restrictions         = [];
-    dependencies         = [4; 10; 7; 5; 6; 8; 9; 20; 17; 18; 25];
+    dependencies         = [4; 10; 7; 5; 28; 8; 9; 20; 17; 18; 25];
     show                 = true;
     rc_filename          = None;
   };
   
-  (* 5 *)
+  (* 6 *)
   "ocamleditor-msvc", {
     descr                = "";
-    num                  = 5;
+    num                  = 6;
     id                   = 15;
     output_name          = "ocamleditor";
     target_type          = Executable;
@@ -3306,10 +3337,10 @@ let targets = [
     rc_filename          = Some ".\\ocamleditor.opt.resource.rc";
   };
   
-  (* 6 *)
+  (* 7 *)
   "ocamleditor-native", {
     descr                = "";
-    num                  = 6;
+    num                  = 7;
     id                   = 11;
     output_name          = "ocamleditor";
     target_type          = Executable;
@@ -3337,10 +3368,10 @@ let targets = [
     rc_filename          = None;
   };
   
-  (* 7 *)
+  (* 8 *)
   "ocamleditor-lib", {
     descr                = "";
-    num                  = 7;
+    num                  = 8;
     id                   = 14;
     output_name          = "ocamleditor_lib";
     target_type          = Library;
@@ -3363,15 +3394,15 @@ let targets = [
     other_objects        = "";
     external_tasks       = [];
     restrictions         = [];
-    dependencies         = [4; 10; 5; 6; 8; 9; 20];
+    dependencies         = [4; 10; 5; 28; 8; 9; 20];
     show                 = true;
     rc_filename          = None;
   };
   
-  (* 8 *)
+  (* 9 *)
   "plugin-remote-bytecode", {
     descr                = "";
-    num                  = 8;
+    num                  = 9;
     id                   = 17;
     output_name          = "../plugins/remote";
     target_type          = Library;
@@ -3399,10 +3430,10 @@ let targets = [
     rc_filename          = None;
   };
   
-  (* 9 *)
+  (* 10 *)
   "plugin-remote-native", {
     descr                = "";
-    num                  = 9;
+    num                  = 10;
     id                   = 16;
     output_name          = "../plugins/remote";
     target_type          = Plugin;
@@ -3430,10 +3461,10 @@ let targets = [
     rc_filename          = None;
   };
   
-  (* 10 *)
+  (* 11 *)
   "plugin-dotviewer-bytecode", {
     descr                = "";
-    num                  = 10;
+    num                  = 11;
     id                   = 18;
     output_name          = "../plugins/dot_viewer_svg";
     target_type          = Library;
@@ -3461,10 +3492,10 @@ let targets = [
     rc_filename          = None;
   };
   
-  (* 11 *)
+  (* 12 *)
   "plugin-dotviewer-native", {
     descr                = "";
-    num                  = 11;
+    num                  = 12;
     id                   = 19;
     output_name          = "../plugins/dot_viewer_svg";
     target_type          = Plugin;
@@ -3492,10 +3523,10 @@ let targets = [
     rc_filename          = None;
   };
   
-  (* 12 *)
+  (* 13 *)
   "plugin-diff-bytecode", {
     descr                = "";
-    num                  = 12;
+    num                  = 13;
     id                   = 25;
     output_name          = "../plugins/plugin_diff";
     target_type          = Library;
@@ -3523,10 +3554,10 @@ let targets = [
     rc_filename          = None;
   };
   
-  (* 13 *)
+  (* 14 *)
   "plugin-diff-native", {
     descr                = "";
-    num                  = 13;
+    num                  = 14;
     id                   = 26;
     output_name          = "../plugins/plugin_diff";
     target_type          = Plugin;
@@ -3554,7 +3585,7 @@ let targets = [
     rc_filename          = None;
   };
   
-  (* 13 *)
+  (* 14 *)
   "prepare-build", {
     descr                = "";
     num                  = 0;
@@ -3585,10 +3616,10 @@ let targets = [
     rc_filename          = None;
   };
   
-  (* 14 *)
+  (* 15 *)
   "launcher", {
     descr                = "Utility to open OCaml files from the file manager";
-    num                  = 14;
+    num                  = 15;
     id                   = 22;
     output_name          = "ocamleditorw";
     target_type          = Executable;
@@ -3616,7 +3647,7 @@ let targets = [
     rc_filename          = Some ".\\ocamleditorw.resource.rc";
   };
   
-  (* 14 *)
+  (* 15 *)
   "tools", {
     descr                = "";
     num                  = 0;
@@ -3647,7 +3678,7 @@ let targets = [
     rc_filename          = None;
   };
   
-  (* 14 *)
+  (* 15 *)
   "FINDLIB-TOOLS", {
     descr                = "";
     num                  = 0;

--- a/install.ml
+++ b/install.ml
@@ -89,6 +89,8 @@ You will need the free NSIS install system (http://nsis.sourceforge.net).";
     end else (sys_command [cp; filename; !!(bin^"/ocamleditor"^exe)]);
     let filename = if Sys.file_exists ("oebuild/oebuild.opt" ^ exe) then ("oebuild/oebuild.opt" ^ exe) else ("oebuild/oebuild" ^ exe) in
     sys_command [cp; !!filename; !!bin];
+    let filename = if Sys.file_exists ("stdlib_pp/stdlib_pp.opt" ^ exe) then ("stdlib_pp/stdlib_pp.opt" ^ exe) else ("stdlib_pp/stdlib_pp" ^ exe) in
+    sys_command [cp; !!filename; !!bin];
     if Sys.win32 && is_mingw then begin
       let basename = "ocamleditor-mingw.bat" in
       sys_command [cp; basename; !!bin];

--- a/ocamleditor.project
+++ b/ocamleditor.project
@@ -138,6 +138,31 @@
       <restrictions></restrictions>
       <dependencies>7</dependencies>
     </target>
+    <target name="stdlib_pp" default="false" id="28" sub_targets="" is_fl_package="false" subsystem="" readonly="false" visible="true" node_collapsed="false">
+      <descr></descr>
+      <byt>true</byt>
+      <opt>true</opt>
+      <libs></libs>
+      <other_objects></other_objects>
+      <files>stdlib_pp/stdlib_pp.ml</files>
+      <package></package>
+      <includes></includes>
+      <thread>false</thread>
+      <vmthread>false</vmthread>
+      <pp></pp>
+      <inline></inline>
+      <nodep>false</nodep>
+      <dontlinkdep>false</dontlinkdep>
+      <dontaddopt>false</dontaddopt>
+      <cflags></cflags>
+      <lflags></lflags>
+      <target_type>Executable</target_type>
+      <outname>stdlib_pp/stdlib_pp</outname>
+      <lib_install_path></lib_install_path>
+      <external_tasks/>
+      <restrictions></restrictions>
+      <dependencies></dependencies>
+    </target>
     <target name="gmisclib" default="false" id="8" sub_targets="" is_fl_package="true" subsystem="" readonly="false" visible="true" node_collapsed="false">
       <descr>Miscellaneous widgets based on LablGtk2.</descr>
       <byt>true</byt>
@@ -236,7 +261,7 @@
       <lib_install_path></lib_install_path>
       <external_tasks/>
       <restrictions></restrictions>
-      <dependencies>4,10,7,5,6,8,9,20,17,18,25</dependencies>
+      <dependencies>4,10,7,5,28,8,9,20,17,18,25</dependencies>
     </target>
     <target name="ocamleditor-msvc" default="false" id="15" sub_targets="" is_fl_package="false" subsystem="Console" readonly="false" visible="true" node_collapsed="false">
       <descr></descr>
@@ -335,7 +360,7 @@
       <lib_install_path></lib_install_path>
       <external_tasks/>
       <restrictions></restrictions>
-      <dependencies>4,10,5,6,8,9,20</dependencies>
+      <dependencies>4,10,5,28,8,9,20</dependencies>
     </target>
     <target name="plugin-remote-bytecode" default="false" id="17" sub_targets="" is_fl_package="false" subsystem="" readonly="false" visible="true" node_collapsed="false">
       <descr></descr>
@@ -801,6 +826,7 @@
       <target target_id="10" show="false"/>
       <target target_id="7" show="false"/>
       <target target_id="5" show="true"/>
+      <target target_id="28" show="true"/>
       <target target_id="8" show="true"/>
       <target target_id="9" show="false"/>
       <target target_id="12" show="true"/>

--- a/src/common/app_config.ml
+++ b/src/common/app_config.ml
@@ -59,11 +59,11 @@ Str.split (Str.regexp ",") ",OCAMLEDITORPARAM=debug=2,,record_backtrace=1,,";;
 let application_param =
   try
     List.fold_left begin fun acc x ->
-      match (*Str.split (Str.regexp "=")*) split '=' x with
-        | n :: v :: [] -> (n, v) :: acc
-        | n :: [] -> (n, "") :: acc
-        | _ -> acc
-    end [] ((*Str.split (Str.regexp ",") *) split ',' (Sys.getenv "OCAMLEDITORPARAM"))
+      match split '=' x with
+      | n :: v :: [] -> (n, v) :: acc
+      | n :: [] -> (n, "") :: acc
+      | _ -> acc
+    end [] (split ',' (Sys.getenv "OCAMLEDITORPARAM"))
   with Not_found -> [];;
 
 let application_debug = try (List.assoc "debug" application_param) = "2" with Not_found -> false;;
@@ -77,10 +77,10 @@ let user_home =
 let ocamleditor_user_home =
   let dirname =
     match Ocaml_config.is_mingw with
-      | true when application_debug -> ".ocamleditor.mingw"
-      | true -> ".ocamleditor.test.mingw"
-      | false when application_debug -> ".ocamleditor.test"
-      | false -> ".ocamleditor"
+    | true when application_debug -> ".ocamleditor.mingw"
+    | true -> ".ocamleditor.test.mingw"
+    | false when application_debug -> ".ocamleditor.test"
+    | false -> ".ocamleditor"
   in
   let ocamleditor_user_home = user_home // dirname in
   if not (Sys.file_exists ocamleditor_user_home) then (Unix.mkdir ocamleditor_user_home 509);
@@ -103,38 +103,41 @@ let application_icons = get_application_dir "icons"
 
 let application_plugins = get_application_dir "plugins"
 
-let get_oebuild_command =
-  let find_best ?(param="--help") prog =
-    let redirect_stderr = if Sys.os_type = "Win32" then " 2>NUL" else " 2>/dev/null" in
-    try
-      List.find begin fun comp ->
-        let ok =
-          try
-            let cmd = sprintf "%s %s%s" (Filename.quote comp) param redirect_stderr in
-            if application_debug then (printf "Checking for %s... %!" cmd);
-            Shell.get_command_output cmd |> ignore;
-            true
-          with _ -> false
-        in
-        if application_debug then (printf "%b\n%!" ok);
-        ok
-      end prog
-    with Not_found ->
-      kprintf failwith "Cannot find: %s" (String.concat ", " prog)
-  in
-  let find_command name =
-    let basename = name ^ (if Sys.win32 then ".exe" else "") in
-    let path = (!! Sys.executable_name) // basename in
-    if Sys.file_exists path && not (Sys.is_directory path) then path
-    else
-      let path = (!! Sys.executable_name) // (if Filename.check_suffix name ".opt" then Filename.chop_extension name else name) // basename in
-      if Sys.file_exists path then path
-      else basename
-  in
-  begin fun () ->
-    let commands = [
-      find_command "oebuild.opt";
-      find_command "oebuild";
-    ] in
-    find_best commands
-  end
+let find_best ?(param="--help") prog =
+  let redirect_stderr = if Sys.os_type = "Win32" then " 2>NUL" else " 2>/dev/null" in
+  try
+    List.find begin fun comp ->
+      let ok =
+        try
+          let cmd = sprintf "%s %s%s" (Filename.quote comp) param redirect_stderr in
+          if application_debug then (printf "Checking for %s... %!" cmd);
+          Shell.get_command_output cmd |> ignore;
+          true
+        with _ -> false
+      in
+      if application_debug then (printf "%b\n%!" ok);
+      ok
+    end prog
+  with Not_found ->
+    kprintf failwith "Cannot find: %s" (String.concat ", " prog)
+
+let find_command name =
+  let basename = name ^ (if Sys.win32 then ".exe" else "") in
+  let path = (!! Sys.executable_name) // basename in
+  if Sys.file_exists path && not (Sys.is_directory path) then path
+  else
+    let path = (!! Sys.executable_name) // (if Filename.check_suffix name ".opt" then Filename.chop_extension name else name) // basename in
+    if Sys.file_exists path then path
+    else basename
+
+let get_oebuild_command () =
+  find_best [
+    find_command "oebuild.opt";
+    find_command "oebuild";
+  ]
+
+let get_stdlib_pp_command =
+  find_best [
+    find_command "stdlib_pp.opt";
+    find_command "stdlib_pp"
+  ]

--- a/src/common/miscellanea.ml
+++ b/src/common/miscellanea.ml
@@ -203,6 +203,25 @@ let replace_first ?(memo=true) =
 (** [starts_with prefix s] restituisce [true] sse [s] inizia con [prefix]. *)
 let starts_with prefix s = string_partial_match (regexp_string prefix) s 0
 
+(** [strip_prefix prefix str]
+
+   If [str] starts with [prefix] strip the prefix from [str], otherwise return
+   [str].
+
+   Example:
+     [strip_prefix "foo__" "foo__bar" = "bar"]
+     [strip_prefix "foo__" "baz" = "baz"]
+*)
+let strip_prefix prefix s =
+  let s_len = String.length s in
+  let prefix_len = String.length prefix in
+  if s_len <= prefix_len then
+    s
+  else if prefix = String.sub s 0 prefix_len then
+    String.sub s prefix_len (s_len - prefix_len)
+  else
+    s
+
 
 (** {6 Ricerca di espressioni regolari} *)
 

--- a/src/stdlib_pp/stdlib_pp.mll
+++ b/src/stdlib_pp/stdlib_pp.mll
@@ -1,0 +1,27 @@
+{}
+
+rule add_stdlib_prefix = parse
+  | "module" [' ' '\t']+ (['A'-'Z' 'a'-'z' '0'-'9']+ as mod_name) ' '+ "=" ' '+  ['A'-'Z' 'a'-'z' '0'-'9']+ 
+  { print_string @@ "module " ^ mod_name ^ " = Stdlib__" ^ (String.uncapitalize_ascii mod_name) }
+  | _ as c
+  { print_char c }
+  | eof
+  { exit 0 }
+
+{
+let main () =
+  let ch =
+    if Array.length Sys.argv > 1 then
+      let filename = Sys.argv.(1) in
+      let _ = print_endline @@ "# 1 \"" ^ filename ^ "\"" in
+      open_in filename 
+    else 
+      stdin 
+  in
+  let lexbuf = Lexing.from_channel ch in
+  while true do
+    add_stdlib_prefix lexbuf
+  done
+
+let _ = Printexc.print main ()
+}

--- a/src/stdlib_pp/stdlib_pp.mll
+++ b/src/stdlib_pp/stdlib_pp.mll
@@ -10,6 +10,15 @@ rule add_stdlib_prefix = parse
 
 {
 let main () =
+  (* This is mostly needed to detect the utiliity from the editor. [stdlib_pp] 
+     with no arguments will just hang. Not good.
+  *)
+  if Array.length Sys.argv > 1 && Sys.argv.(1) = "--help" then
+  begin
+    Format.printf "Usage: %s [filename]\n" @@ Filename.basename Sys.executable_name;
+    exit 0
+  end;
+
   let ch =
     if Array.length Sys.argv > 1 then
       let filename = Sys.argv.(1) in

--- a/tools/install.ml
+++ b/tools/install.ml
@@ -89,6 +89,8 @@ You will need the free NSIS install system (http://nsis.sourceforge.net).";
     end else (sys_command [cp; filename; !!(bin^"/ocamleditor"^exe)]);
     let filename = if Sys.file_exists ("oebuild/oebuild.opt" ^ exe) then ("oebuild/oebuild.opt" ^ exe) else ("oebuild/oebuild" ^ exe) in
     sys_command [cp; !!filename; !!bin];
+    let filename = if Sys.file_exists ("stdlib_pp/stdlib_pp.opt" ^ exe) then ("stdlib_pp/stdlib_pp.opt" ^ exe) else ("stdlib_pp/stdlib_pp" ^ exe) in
+    sys_command [cp; !!filename; !!bin];
     if Sys.win32 && is_mingw then begin
       let basename = "ocamleditor-mingw.bat" in
       sys_command [cp; basename; !!bin];

--- a/tools/prepare_build.ml
+++ b/tools/prepare_build.ml
@@ -43,6 +43,7 @@ let prepare_build () =
     if not (Sys.file_exists "../plugins") then (mkdir "../plugins");
     run "ocamllex err_lexer.mll";
     run "ocamlyacc err_parser.mly";
+    run "ocamllex stdlib_pp/stdlib_pp.mll";
     if not is_win32 then begin
       (* Disabled because on Windows it changes the file permissions of oe_config.ml
          forcing it to be recompiled for plugins.*)
@@ -53,8 +54,8 @@ let prepare_build () =
     (try generate_oebuild_script() with Failure msg -> raise (Script_error ("generate_oebuild_script()", 2)));
     (*  *)
     let chan = open_out_bin "../src/build_id.ml" in
-    kprintf (output_string chan) "let timestamp = \"%f\"" (Unix.gettimeofday ());
-    kprintf (output_string chan) "\nlet git_hash = %S" (get_command_output "git rev-parse HEAD" |> List.hd);
+    kprintf (output_string chan) "let timestamp = \"%f\"\n" (Unix.gettimeofday ());
+    kprintf (output_string chan) "let git_hash = %S\n" (get_command_output "git rev-parse HEAD" |> List.hd);
     close_out_noerr chan;
     (*  *)
     print_newline()


### PR DESCRIPTION
When the OCaml standard library has transitioned from Pervasives to Stdlib there were some changes which make the processing of {.ml,.mli} files with ocamldoc somewhat involved. Just try it
```
$ camldoc $OPAM_SWITCH_PREFIX/lib/ocaml/stdlib.mli
File /lib/ocaml/stdlib.mli", line 1349, characters 22-25:
1349 | module Arg          = Arg
                             ^^^
Error: Unbound module Arg
1 error(s) encountered
```

Ocamldoc looks into compiled `.cmi` file for additional info about references modules, but there is nor `arg.cmi` file in stdlib directory because there is a 'stdlib__arg.cmi'. At the same time there are `arg.ml`, `arg.mli` files there.

To deal with it a preprocessing step for ocamldoc is added it looks likes this 
```
pp \
"gawk -v ocamldoc=true -f ../stdlib/expand_module_aliases.awk" \
```

This PR does something similar but without gawk.
