### PR TITLE
Do not indent non OCaml files.

### DIFF
--- a/src/editor.ml
+++ b/src/editor.ml
@@ -454,8 +454,8 @@ class editor () =
               let nlines = stop#line - start#line in
               let nchars = stop#offset - start#offset in
               kprintf page#status_pos_sel#set_text "%d (%d)" nlines nchars;
-              if is_insert then 
-                Timeout.set tout_fast 0 page#view#mark_occurrences_manager#mark 
+              if is_insert then
+                Timeout.set tout_fast 0 page#view#mark_occurrences_manager#mark
             end else begin
               page#view#mark_occurrences_manager#clear();
               page#status_pos_sel#set_text "0";
@@ -675,13 +675,15 @@ class editor () =
       | _ -> Dialog_rename.window ~editor:self ~page ()
 
     method save (page : Editor_page.page) =
+      let filename = page#get_filename in
+      let extension = Filename.extension filename in
       let pref = Preferences.preferences#get in
       if pref.pref_editor_trim_lines
       then page#buffer#trim_lines ();
       if pref.pref_editor_format_on_save
-      then ignore @@ Ocp_indent.indent ~project: self#project ~view:page#view `ALL;
+      then ignore @@ Ocp_indent.indent_for_extension ~project: self#project ~view:page#view ~extension `ALL;
       page#save();
-      file_saved#call page#get_filename;
+      file_saved#call filename;
 
     method dialog_confirm_close = Editor_dialog.confirm_close ~editor:self
 

--- a/src/ocp_indent.ml
+++ b/src/ocp_indent.ml
@@ -39,7 +39,13 @@ let find_ocp_indent_config' project =
 
 let find_ocp_indent_config = Miscellanea.Memo.fast ~f:find_ocp_indent_config'
 
-let indent_config ~project ~pref =
+let indent_config ~project ~pref ?(syntaxes=[]) () =
+  Approx_lexer.disable_extensions ();
+  List.iter
+    (fun syntax -> try Approx_lexer.enable_extension syntax
+      with IndentExtend.Syntax_not_found name ->
+        Format.eprintf "Warning: unknown syntax extension %S@." name)
+    syntaxes;
   match find_ocp_indent_config project with
   | Some file_config -> IndentConfig.(update_from_string default file_config)
   | None ->
@@ -50,9 +56,9 @@ let indent_config ~project ~pref =
 
 let collect (n : int) offsets = n :: offsets
 
-let output ~project ~pref start stop = IndentPrinter.{
+let output ~project ~pref ?syntaxes start stop = IndentPrinter.{
     debug = false;
-    config = indent_config ~project ~pref;
+    config = indent_config ~project ~pref ?syntaxes ();
     in_lines = (fun n -> n >= start && n <= stop);
     indent_empty = false;
     adaptive = false;
@@ -82,7 +88,7 @@ let contents (buffer : GText.buffer) =
   buffer#get_text ~start ~stop ()
 
 (** indent *)
-let indent ~project ~view bounds =
+let indent ~project ~view ?syntaxes bounds =
   let pref = Preferences.preferences#get in
   let buffer = view#tbuffer in
   let indent () =
@@ -99,7 +105,7 @@ let indent ~project ~view bounds =
 
     let contents = contents buffer#as_gtext_buffer in
     let ns = Nstream.of_string contents in
-    let offsets = IndentPrinter.proceed (output ~project ~pref start_line stop_line) ns IndentBlock.empty [] in
+    let offsets = IndentPrinter.proceed (output ~project ~pref ?syntaxes start_line stop_line) ns IndentBlock.empty [] in
     let lines = List.rev offsets in
 
     buffer#undo#begin_block ~name:"ocp-indent";
@@ -141,3 +147,9 @@ let indent ~project ~view bounds =
       (if pref.Preferences.pref_editor_indent_empty_line then indent() else false)
     else if ins#ends_line then false else indent ()
   end else indent ()
+
+let indent_for_extension ~project ~view ~extension bounds =
+  match extension with
+  | ".ml" | ".mli" -> ignore @@ indent ~project ~view bounds
+  | ".mll" -> ignore @@ indent ~project ~view ~syntaxes: ["mll"] bounds
+  | _ -> ()


### PR DESCRIPTION
This fixes the minor but embarrassing bug, where
if the 'format on save' box is checked the editor will
try to indent as OCaml files all files.

The result can be surprising, especially if the file
contains some OCaml keywords. If, for example. Or for.

As a small extra, I've added support for indentation
of ocamllex `.mll`, files. For the moment, just on save.

Also we need to disable the Indent/Indent All for files
for which this is not supported.

But that's another issue.

@ftovagliari you may want to see this.